### PR TITLE
Restore start-editing-on-insert without regressing #69

### DIFF
--- a/src/plugins/GraphEditor/ClassRenderer.h
+++ b/src/plugins/GraphEditor/ClassRenderer.h
@@ -53,6 +53,12 @@ public:
 				void		ResizeBy(float dx,float dy);
 				bool		Selected(void){return selected;};
 				BMessage*	Parent(void){return parentNode;};
+				/** puts the name label straight into edit mode - used right
+				 * after a fresh insert so the user can type a name
+				 * immediately, without simulating it on every construction
+				 * (that used to also fire on a plain document load, see #69)
+				 */
+				void		StartEditingName(void){name->MouseDown(BPoint(0,0));};
 
 
 protected:

--- a/src/plugins/GraphEditor/GraphEditor.cpp
+++ b/src/plugins/GraphEditor/GraphEditor.cpp
@@ -31,6 +31,7 @@
 
 
 const char		*G_E_TOOL_BAR			= "G_E_TOOL_BAR";
+const char		*G_E_START_EDITING_NAME	= "GraphEditor::StartEditingName";
 
 GraphEditor::GraphEditor(image_id newId):PEditor(),BView(BRect(0,0,400,400),"GraphEditor",B_FOLLOW_ALL_SIDES,B_WILL_DRAW | B_NAVIGABLE) {
 	TRACE();
@@ -834,6 +835,8 @@ void GraphEditor::InsertObject(BPoint where,bool deselect) {
 	newObject->AddRect(P_C_NODE_FRAME,BRect(where,where+BPoint(100,40)));
 	newObject->AddMessage(P_C_NODE_FONT,newFont);
 	newObject->AddMessage(P_C_NODE_PATTERN,newPattern);
+	if (newObject->what == P_C_CLASS_TYPE)
+		newObject->AddBool(G_E_START_EDITING_NAME,true);
 	//preparing CommandMessage
 	commandMessage->AddPointer("node",(void *)newObject);
 	commandMessage->AddString("Command::Name","Insert");
@@ -888,6 +891,12 @@ Renderer* GraphEditor::CreateRendererFor(BMessage *node)
 	// practice, usually wrong (issue #36 follow-up).
 	if (newRenderer != NULL)
 		AddRenderer(newRenderer);
+	bool	startEditing	= false;
+	if ((node->what == P_C_CLASS_TYPE) &&
+	    (node->FindBool(G_E_START_EDITING_NAME,&startEditing) == B_OK) && startEditing) {
+		node->RemoveName(G_E_START_EDITING_NAME);
+		((ClassRenderer*)newRenderer)->StartEditingName();
+	}
 	return newRenderer;
 }
 
@@ -1066,6 +1075,8 @@ BMessage *GraphEditor::GenerateInsertCommand(uint32 newWhat, bool connected)
 		where.y = where.y-fmod(where.y,GridWidth());
 	}
 	newNode->what = newWhat;
+	if (newWhat == P_C_CLASS_TYPE)
+		newNode->AddBool(G_E_START_EDITING_NAME,true);
 	newNode->AddMessage(P_C_NODE_FONT,newFont);
 	newNode->AddMessage(P_C_NODE_PATTERN,newPattern);
 	commandMessage->AddString("Command::Name","Insert");

--- a/src/plugins/GraphEditor/GraphEditor.h
+++ b/src/plugins/GraphEditor/GraphEditor.h
@@ -42,6 +42,10 @@ const uint32			G_E_INSERT_NODE 		= 'geIN';
 const uint32            G_E_INSERT_SIBLING      = 'geIS';
 
 extern const char		*G_E_TOOL_BAR;		//	= "G_E_TOOL_BAR";
+// transient field on a freshly inserted node's own BMessage, checked once by
+// CreateRendererFor() and removed right after - not part of the saved
+// document format
+extern const char		*G_E_START_EDITING_NAME;	//	= "GraphEditor::StartEditingName";
 
 const float		triangleHeight	= 7;
 const float		gridWidth		= 50;


### PR DESCRIPTION
Stack: 3/5 (based on #77, not master).

The #69 fix removed `ClassRenderer`'s unconditional `name->MouseDown(BPoint(0,0))` constructor call (it was putting *every* node into edit mode on *every* load). That also removed the one legitimate thing it did: letting you type a name immediately after inserting a new node.

Reintroduced narrowly: `GenerateInsertCommand()`/`InsertObject()` (the two places a user actually creates a new class node) tag it with a transient `G_E_START_EDITING_NAME` flag, consumed once by `CreateRendererFor()` and removed immediately — never reaches a save, so it can't reintroduce #69.