### PR TITLE
Fix Group::Undo leaving stale P_C_NODE_PARENT, breaking redo

### DIFF
--- a/src/plugins/GroupCommand/Group.cpp
+++ b/src/plugins/GroupCommand/Group.cpp
@@ -20,6 +20,12 @@ void Group::Undo(PDocument *doc,BMessage *undo) {
 		if ( (node->FindPointer(P_C_NODE_ALLNODES,(void **)&subList) == B_OK) && (subList) ) {
 			while (subList->CountItems()>0) {
 				subNode	= (BMessage *)subList->RemoveItem((int32)0);
+				// Do() only re-groups a node whose P_C_NODE_PARENT isn't
+				// already set (see Group::Do()'s guard) - leaving it here
+				// after ungrouping made every child look "already grouped"
+				// to a later redo, which then silently skipped re-adding
+				// them to the group's own list at all
+				subNode->RemoveName(P_C_NODE_PARENT);
 				allNodes->AddItem(subNode);
 				changed->insert(subNode);
 			}

--- a/src/tests/PCommandTest.cpp
+++ b/src/tests/PCommandTest.cpp
@@ -153,3 +153,47 @@ void PCommandTest::GroupThenInsertChildRegistersInParentList(void)
 	CPPUNIT_ASSERT(doc->GetAllNodes()->HasItem(&newChild));
 	CPPUNIT_ASSERT(groupAllNodes->HasItem(&newChild));
 }
+
+void PCommandTest::GroupUndoThenRedoKeepsChildren(void)
+{
+	// regression test for a bug found while live-testing #38's fixes:
+	// Group::Undo() removed a child from the group's own P_C_NODE_ALLNODES
+	// list but never cleared P_C_NODE_PARENT on the child itself. Redo runs
+	// Group::Do() again on the same two nodes - which only (re-)groups a
+	// node whose P_C_NODE_PARENT isn't already set (see its guard) - so the
+	// stale leftover parent pointer made every child look "already grouped"
+	// and Do() silently skipped re-adding any of them.
+	PDocument	*doc	= NewHeadlessTestDocument();
+
+	BMessage	child1(P_C_CLASS_TYPE);
+	child1.AddRect(P_C_NODE_FRAME,BRect(0,0,50,50));
+	BMessage	child2(P_C_CLASS_TYPE);
+	child2.AddRect(P_C_NODE_FRAME,BRect(100,0,150,50));
+	doc->GetAllNodes()->AddItem(&child1);
+	doc->GetAllNodes()->AddItem(&child2);
+	doc->GetSelected()->AddItem(&child1);
+	doc->GetSelected()->AddItem(&child2);
+
+	BMessage	groupNode(P_C_GROUP_TYPE);
+	BMessage	groupSettings;
+	groupSettings.AddPointer("node",&groupNode);
+
+	Group		groupCommand;
+	BMessage	*result	= groupCommand.Do(doc,&groupSettings);
+	CPPUNIT_ASSERT(result != NULL);
+
+	groupCommand.Undo(doc,result);
+
+	void	*parent	= NULL;
+	CPPUNIT_ASSERT(child1.FindPointer(P_C_NODE_PARENT,&parent) != B_OK);
+	CPPUNIT_ASSERT(child2.FindPointer(P_C_NODE_PARENT,&parent) != B_OK);
+
+	// redo: same settings message, same current selection - matches what
+	// PCommandManager::Redo() actually replays
+	groupCommand.Do(doc,&groupSettings);
+
+	BList	*groupAllNodes	= NULL;
+	CPPUNIT_ASSERT(groupNode.FindPointer(P_C_NODE_ALLNODES,(void **)&groupAllNodes) == B_OK);
+	CPPUNIT_ASSERT(groupAllNodes->HasItem(&child1));
+	CPPUNIT_ASSERT(groupAllNodes->HasItem(&child2));
+}

--- a/src/tests/PCommandTest.h
+++ b/src/tests/PCommandTest.h
@@ -14,11 +14,13 @@ public:
 	void ChangeValueDoUndo(void);
 	void ChangeValueOnSelectionDoUndo(void);
 	void GroupThenInsertChildRegistersInParentList(void);
+	void GroupUndoThenRedoKeepsChildren(void);
 
 	CPPUNIT_TEST_SUITE(PCommandTest);
 	CPPUNIT_TEST(ChangeValueDoUndo);
 	CPPUNIT_TEST(ChangeValueOnSelectionDoUndo);
 	CPPUNIT_TEST(GroupThenInsertChildRegistersInParentList);
+	CPPUNIT_TEST(GroupUndoThenRedoKeepsChildren);
 	CPPUNIT_TEST_SUITE_END();
 };
 


### PR DESCRIPTION
Stack: 5/5 (based on #79, not master).

`Group::Undo()` drained the group's own node list and moved children back to the document's top-level list, but never cleared `P_C_NODE_PARENT` on the children themselves. `Group::Do()` only (re-)groups a node whose `P_C_NODE_PARENT` isn't already set, so a subsequent redo silently skipped every child — found by live-testing group → undo → redo, where the children ended up detached from the group after redoing.

Includes a regression test driving `Group::Do() -> Undo() -> Do()` through the real command class (headless, no GUI).