### PR TITLE
Fix double-free crash on group undo/redo (single-owner renderer deletion)

### DIFF
--- a/src/plugins/GraphEditor/GraphEditor.cpp
+++ b/src/plugins/GraphEditor/GraphEditor.cpp
@@ -917,25 +917,25 @@ void GraphEditor::RemoveRenderer(Renderer *wichRenderer) {
 			mouseReciver = NULL;
 		if (wichRenderer->GetMessage())
 			(wichRenderer->GetMessage())->RemoveName(renderString);
-		// A grouped renderer is registered both here (added once when its
-		// node was first created) and in its GroupRenderer's own list
-		// (GroupRenderer::InsertRenderObject). It has to come out of this
-		// list unconditionally, whichever owner ends up deleting it -
-		// otherwise DetachedFromWindow()'s drain loop keeps re-reading the
-		// same (already freed) pointer and either double-frees or spins
-		// forever.
 		renderer->RemoveItem(wichRenderer);
-		//check if this rendere belongs to the grapheditor or if not it belongs to a group so the group will take care to remove the renderer from its renderlist
+		// A grouped renderer is also tracked in its GroupRenderer's own
+		// `renderer` list (bookkeeping for cascading MoveBy/ResizeBy to
+		// children, see CreateRendererFor()) - drop it from there too, but
+		// GraphEditor is the only place that ever deletes a renderer.
+		// Letting the group also delete it (the previous design) meant two
+		// independent code paths could each decide they own the same
+		// object's lifetime - GroupRenderer::ValueChanged()'s own scan over
+		// changedNodes calls RemoveRenderer() on a child that's fallen out
+		// of the group *without* going through here at all, so whichever of
+		// the two ran first left the other holding a dangling pointer it
+		// would eventually double-free.
 		ClassRenderer* cRenderer = dynamic_cast <ClassRenderer*>(wichRenderer);
 		GroupRenderer* gRenderer = NULL;
 		if ((cRenderer != NULL) && (cRenderer->Parent() != NULL))
 			gRenderer = (GroupRenderer*)FindRenderer(cRenderer->Parent());
-		if (gRenderer != NULL) {
-			// the group owns this renderer's lifetime and deletes it
+		if (gRenderer != NULL)
 			gRenderer->RemoveRenderer(wichRenderer);
-		} else {
-			delete wichRenderer;
-		}
+		delete wichRenderer;
 	}
 /*	delete rendersensitv;
 	rendersensitv = new BRegion();

--- a/src/plugins/GraphEditor/GroupRenderer.cpp
+++ b/src/plugins/GraphEditor/GroupRenderer.cpp
@@ -117,9 +117,13 @@ void GroupRenderer::AddRenderer(Renderer* newRenderer) {
 
 void GroupRenderer::RemoveRenderer(Renderer *wichRenderer) {
 	TRACE();
+	// bookkeeping only - GraphEditor::RemoveRenderer() is the single place
+	// that ever deletes a renderer (see the comment there). This just drops
+	// it from this group's own child list, e.g. because it fell out of the
+	// group's P_C_NODE_ALLNODES (GroupRenderer::ValueChanged()) or is being
+	// removed via GraphEditor::RemoveRenderer()'s delegation - either way
+	// the object may still be alive and owned elsewhere.
 	renderer->RemoveItem(wichRenderer);
-	delete wichRenderer;
-	wichRenderer=NULL;
 }
 
 


### PR DESCRIPTION
Stack: 6/6 (based on #80, not master).

Reproduced live while testing the rest of this stack: group two nodes, undo, redo → crash. Confirmed via the Haiku debug_server crash report - double-free inside `GroupRenderer::RemoveRenderer()`, called from `GraphEditor::ProcessChangedNode()`.

Root cause: two independent code paths could each decide they owned a renderer's lifetime and delete it - `GraphEditor::RemoveRenderer()`'s delegation to a group, and `GroupRenderer::ValueChanged()`'s own `RemoveRenderer()` call on a child that fell out of the group's node list, with no coordination between them.

Fix: GraphEditor is now the single, exclusive owner of renderer deletion. `GroupRenderer::RemoveRenderer()` only touches its own bookkeeping list now (consistent with its Draw-time role from #77 - it was never meant to be a second authority, drawing or otherwise).