### PR TITLE
Harden AddRenderer() against duplicate list entries

### DIFF
--- a/src/plugins/GraphEditor/GraphEditor.cpp
+++ b/src/plugins/GraphEditor/GraphEditor.cpp
@@ -902,7 +902,14 @@ Renderer* GraphEditor::CreateRendererFor(BMessage *node)
 
 void GraphEditor::AddRenderer(Renderer* newRenderer) {
 	TRACE();
-	renderer->AddItem(newRenderer);
+	// RemoveRenderer() only removes the first matching entry from this list
+	// (BList::RemoveItem() - verified against Haiku's own List.cpp, it does
+	// an IndexOf() + single removal). A duplicate entry here would survive
+	// that removal as a dangling pointer once the object is deleted, and
+	// the next Draw() pass would read freed memory through it - guard
+	// against ever creating that duplicate in the first place.
+	if (!renderer->HasItem(newRenderer))
+		renderer->AddItem(newRenderer);
 	BringToFront(newRenderer);
 	activRenderer = newRenderer;
 }

--- a/src/plugins/GraphEditor/GroupRenderer.cpp
+++ b/src/plugins/GraphEditor/GroupRenderer.cpp
@@ -112,7 +112,11 @@ void GroupRenderer::InsertRenderObject(BMessage *node) {
 
 void GroupRenderer::AddRenderer(Renderer* newRenderer) {
 	TRACE();
-	renderer->AddItem(newRenderer);
+	// see the same guard in GraphEditor::AddRenderer() - RemoveRenderer()
+	// only drops the first matching entry, so a duplicate here would leave
+	// a second, stale reference in this group's own bookkeeping list
+	if (!renderer->HasItem(newRenderer))
+		renderer->AddItem(newRenderer);
 }
 
 void GroupRenderer::RemoveRenderer(Renderer *wichRenderer) {


### PR DESCRIPTION
Stack: 7/7 (based on #81, not master).

Hit a second, different crash live-testing #81's fix: GPF inside `GraphEditor::DrawRenderer()`, reading a freed/garbage pointer out of the top-level render list.

Verified against Haiku's real `List.cpp`: `BList::RemoveItem(void*)` only removes the *first* matching entry (`IndexOf()` + single removal). If a renderer pointer were ever added twice to the same list, `RemoveRenderer()`'s one `RemoveItem()` call leaves a second, dangling copy behind - exactly matching what the crash report showed (garbage-looking vtable/member values at the crash address, consistent with freed memory already reused for something else).

I have not pinned down the exact sequence that adds a renderer twice. This closes the failure mode structurally (`AddRenderer()` checks `HasItem()` first, in both `GraphEditor` and `GroupRenderer`) rather than leaving it open while the precise trigger gets chased down - flagging that explicitly rather than presenting this as a fully root-caused fix.