### PR TITLE
Fix bended connections never being click-selectable

### DIFF
--- a/src/plugins/GraphEditor/ConnectionRenderer.cpp
+++ b/src/plugins/GraphEditor/ConnectionRenderer.cpp
@@ -293,7 +293,15 @@ bool ConnectionRenderer::CaughtStraigt(BPoint where){
 }
 
 bool ConnectionRenderer::CaughtBended(BPoint where){
-	if (bezier.Bounds().Contains(where) == true )
+	// bezier's own points are relative to fromPoint (built via MoveTo(0,0) +
+	// offset control points in DrawBended()) - only StrokeShape()'s implicit
+	// MovePenTo(fromPoint) translates that to screen/document space at draw
+	// time, so Bounds() alone is in the wrong coordinate space entirely and
+	// essentially never contains `where` (an absolute click point) unless
+	// fromPoint happens to sit near the origin. PointOnBezier() below
+	// already works in absolute coordinates, so only this bounding check
+	// needed the offset.
+	if (bezier.Bounds().OffsetByCopy(fromPoint).Contains(where) == true )
 	{
 		float t = 0;
 		float minDist=999999;


### PR DESCRIPTION
Stack: 8/9 (based on #82, not master).

`CaughtBended()` (connection type 1 - what every hand-dragged connection between two nodes gets, per `GraphEditor.cpp`'s `G_E_CONNECTED` handler) used `bezier.Bounds().Contains(where)` as a fast pre-filter. The `BShape`'s own points are relative to `fromPoint` (built via `MoveTo(0,0)` plus offset control points in `DrawBended()`, only translated to absolute space implicitly by `StrokeShape()`'s `MovePenTo(fromPoint)` at draw time) - so `Bounds()` alone is in the wrong coordinate space and rejects virtually every real click before the actual (correct) distance-sampling loop runs.

Confirmed live with instrumented debug output: a click 2-3px from the line reported "missed".

Different bug from #26/#82 (those fixed connection types 0/2 - straight/angled). Bended is the default for hand-drawn connections, so probably the more commonly-hit of the two.