### PR TITLE
Line-buffer stdout/stderr for reliable live debug logging

### DIFF
--- a/src/app/ProjectConceptor.cpp
+++ b/src/app/ProjectConceptor.cpp
@@ -14,6 +14,7 @@
 #include <translation/TranslationUtils.h>
 
 #include <string.h>
+#include <stdio.h>
 
 
 ProjektConceptor::ProjektConceptor():BApplication(APP_SIGNATURE) {
@@ -167,6 +168,12 @@ void ProjektConceptor::RegisterMime(void) {
 
 int main()
 {
+	// stdout/stderr default to fully-buffered when redirected to a file (not
+	// a TTY) - debug.log then only gets what's been flushed, which for a
+	// still-running, non-crashed process can lag far behind what's actually
+	// happened. Line-buffered keeps it current for live debugging.
+	setvbuf(stdout, NULL, _IOLBF, 0);
+	setvbuf(stderr, NULL, _IOLBF, 0);
 
 	new ProjektConceptor();
 	/*	freopen ("/boot/var/log/ProjectConceptor.log","w",stdout);


### PR DESCRIPTION
Stack: 9/9 (based on #83, not master).

Small tooling/quality-of-life fix, not a functional bug - found while investigating #83. `stdout`/`stderr` default to fully-buffered when redirected to a file (what every `dev.sh` command does), so `debug.log` for a still-running process can lag far behind what actually happened. Cost real time during today's connection-click investigation before this was identified as the reason recent `PRINT()`/`TRACE()` output wasn't showing up in fetched logs.

Line-buffered flushes on every newline, which is how nearly all of this codebase's debug output already terminates, keeping `debug.log` current without needing to kill the process first.