### PR TITLE
Make Pen size/Fill color actually affect connections

### DIFF
--- a/src/plugins/GraphEditor/ConnectionRenderer.cpp
+++ b/src/plugins/GraphEditor/ConnectionRenderer.cpp
@@ -20,6 +20,7 @@ void ConnectionRenderer::Init() {
 	toPoint			= BPoint(0,0);
 	selected		= false;
 	fillColor		= make_color(187,67,47,255);
+	penSize			= 2.0;
 	connectionType	= 2;
 	bezier			= BShape();
 
@@ -122,6 +123,15 @@ void ConnectionRenderer::ValueChanged() {
 	tmpNode->FindPointer(editor->RenderString(),(void **)&to);
 	container->FindBool(P_C_NODE_SELECTED,&selected);
 	container->FindInt8(P_C_NODE_CONNECTION_TYPE, (int8 *)&connectionType);
+	// same P_C_NODE_PATTERN sub-message a class node has - the Pen size/Fill
+	// color toolbar controls (GraphEditor.cpp's G_E_PEN_SIZE_CHANGED/
+	// G_E_COLOR_CHANGED) go through ChangeValue targeting exactly these two
+	// fields there, regardless of node type
+	BMessage	pattern;
+	if (container->FindMessage(P_C_NODE_PATTERN,&pattern) == B_OK) {
+		pattern.FindFloat("PenSize",&penSize);
+		pattern.FindInt32("FillColor",(int32 *)&fillColor);
+	}
 }
 
 void ConnectionRenderer::CalcLine() {
@@ -215,7 +225,7 @@ bool ConnectionRenderer::Caught(BPoint where){
 }
 
 void ConnectionRenderer::DrawStraight(BView *drawOn, BRect updateRect){
-		drawOn->SetPenSize(2.0);
+		drawOn->SetPenSize(penSize);
 		BPoint	shadowFrom		= fromPoint;
 		BPoint	shadowTo		= toPoint;
 		BPoint	shadowfirst		= first;
@@ -239,7 +249,7 @@ void ConnectionRenderer::DrawStraight(BView *drawOn, BRect updateRect){
 }
 
 void ConnectionRenderer::DrawBended(BView *drawOn, BRect updateRect){
-	drawOn->SetPenSize(2.0);
+	drawOn->SetPenSize(penSize);
 	if (!selected)
 		drawOn->SetHighColor(fillColor);
 	else
@@ -256,7 +266,7 @@ void ConnectionRenderer::DrawBended(BView *drawOn, BRect updateRect){
 }
 
 void ConnectionRenderer::DrawAngled(BView *drawOn, BRect updateRect){
-	drawOn->SetPenSize(2.0);
+	drawOn->SetPenSize(penSize);
 	BPoint	shadowFrom		= fromPoint;
 	BPoint	shadowTo		= toPoint;
 	BPoint	shadowfirst		= first;

--- a/src/plugins/GraphEditor/ConnectionRenderer.h
+++ b/src/plugins/GraphEditor/ConnectionRenderer.h
@@ -67,6 +67,7 @@ protected:
 	bool				selected;
 	BPoint				first,second,third;
 	rgb_color			fillColor;
+	float				penSize;
 	ClassRenderer		*from;
 	ClassRenderer		*to;
 	BPoint				fromPoint;

--- a/src/plugins/GraphEditor/GraphEditor.cpp
+++ b/src/plugins/GraphEditor/GraphEditor.cpp
@@ -692,7 +692,18 @@ void GraphEditor::MessageReceived(BMessage *message) {
 				connection->AddPointer(P_C_NODE_CONNECTION_TO,to);
 				connection->AddMessage(P_C_NODE_DATA,data);
 				connection->AddInt8(P_C_NODE_CONNECTION_TYPE,1);
-				
+				// deliberately NOT the toolbar's current color/pen size -
+				// those default to values tuned for node fills, easy to end
+				// up pale/thin enough that a brand-new connection is barely
+				// visible. Matches ConnectionRenderer's own old hardcoded
+				// Init() default. Still fully changeable afterwards via the
+				// same Pen size/Fill color controls once selected - this is
+				// only the starting point.
+				BMessage	*connectionPattern	= new BMessage();
+				rgb_color	defaultConnectionColor	= make_color(187,67,47,255);
+				connectionPattern->AddInt32("FillColor",*(int32 *)&defaultConnectionColor);
+				connectionPattern->AddFloat("PenSize",2.0f);
+				connection->AddMessage(P_C_NODE_PATTERN,connectionPattern);
 				connection->AddPointer("ProjectConceptor::doc",doc);
 				//** add the connections to the Nodes :-)
 				commandMessage->AddPointer("node",connection);
@@ -1115,6 +1126,13 @@ BMessage *GraphEditor::GenerateInsertCommand(uint32 newWhat, bool connected)
 					uint	cType	= 1;
 					connection->AddInt8(P_C_NODE_CONNECTION_TYPE, cType);
 					connection->AddMessage(P_C_NODE_DATA,data);
+					// see the G_E_CONNECTED handler above for why this isn't
+					// the toolbar's current color/pen size
+					BMessage	*connectionPattern	= new BMessage();
+					rgb_color	defaultConnectionColor	= make_color(187,67,47,255);
+					connectionPattern->AddInt32("FillColor",*(int32 *)&defaultConnectionColor);
+					connectionPattern->AddFloat("PenSize",2.0f);
+					connection->AddMessage(P_C_NODE_PATTERN,connectionPattern);
 					connection->AddPointer("ProjectConceptor::doc",doc);
 					//** add the connections to the Nodes :-)
 					commandMessage->AddPointer("node",connection);

--- a/src/tests/PCommandTest.cpp
+++ b/src/tests/PCommandTest.cpp
@@ -110,6 +110,45 @@ void PCommandTest::ChangeValueOnSelectionDoUndo(void)
 	CPPUNIT_ASSERT_EQUAL(2.0f,restored2);
 }
 
+void PCommandTest::ChangeValueOnConnectionPattern(void)
+{
+	// regression test: connections used to never get a P_C_NODE_PATTERN
+	// sub-message at all, so the Pen size/Fill color toolbar controls
+	// (which go through ChangeValue targeting "PenSize"/"FillColor" inside
+	// that sub-message, same as for a class node) silently did nothing for
+	// a selected connection - DoChangeValue()'s FindData/ReplaceData both
+	// failed quietly against a message that was never there.
+	PDocument	*doc	= NewHeadlessTestDocument();
+
+	BMessage	pattern;
+	pattern.AddFloat("PenSize",2.0f);
+	pattern.AddInt32("FillColor",0xff43439a);
+	BMessage	connection(P_C_CONNECTION_TYPE);
+	connection.AddMessage(P_C_NODE_PATTERN,&pattern);
+
+	doc->GetSelected()->AddItem(&connection);
+
+	BMessage	valueContainer;
+	valueContainer.AddString("name","PenSize");
+	valueContainer.AddString("subgroup",P_C_NODE_PATTERN);
+	valueContainer.AddInt32("type",(int32)B_FLOAT_TYPE);
+	valueContainer.AddFloat("newValue",5.0f);
+
+	BMessage	settings;
+	settings.AddBool(P_C_NODE_SELECTED,true);
+	settings.AddMessage("valueContainer",&valueContainer);
+
+	ChangeValue	command;
+	BMessage	*result	= command.Do(doc,&settings);
+	CPPUNIT_ASSERT(result != NULL);
+
+	BMessage	changedPattern;
+	CPPUNIT_ASSERT(connection.FindMessage(P_C_NODE_PATTERN,&changedPattern) == B_OK);
+	float	changedPenSize	= 0;
+	CPPUNIT_ASSERT(changedPattern.FindFloat("PenSize",&changedPenSize) == B_OK);
+	CPPUNIT_ASSERT_EQUAL(5.0f,changedPenSize);
+}
+
 void PCommandTest::GroupThenInsertChildRegistersInParentList(void)
 {
 	// regression test for issue #36: double-clicking a group node inserts a

--- a/src/tests/PCommandTest.h
+++ b/src/tests/PCommandTest.h
@@ -13,12 +13,14 @@ class PCommandTest : public CppUnit::TestFixture
 public:
 	void ChangeValueDoUndo(void);
 	void ChangeValueOnSelectionDoUndo(void);
+	void ChangeValueOnConnectionPattern(void);
 	void GroupThenInsertChildRegistersInParentList(void);
 	void GroupUndoThenRedoKeepsChildren(void);
 
 	CPPUNIT_TEST_SUITE(PCommandTest);
 	CPPUNIT_TEST(ChangeValueDoUndo);
 	CPPUNIT_TEST(ChangeValueOnSelectionDoUndo);
+	CPPUNIT_TEST(ChangeValueOnConnectionPattern);
 	CPPUNIT_TEST(GroupThenInsertChildRegistersInParentList);
 	CPPUNIT_TEST(GroupUndoThenRedoKeepsChildren);
 	CPPUNIT_TEST_SUITE_END();


### PR DESCRIPTION
Stack: 10/10 (based on #84, not master).

Two gaps meant Pen size/Fill color silently did nothing for a selected connection: connections never got a `P_C_NODE_PATTERN` sub-message at creation (unlike every class node) for `ChangeValue` to target, and `ConnectionRenderer` never read pattern data back out anyway - `Draw*()` hardcoded `SetPenSize(2.0)` and never looked at the container's pattern at all.

New connections get a fixed red/2.0pt default pattern (not the toolbar's current color/pen-size - those are tuned for node fills and would leave a brand-new connection barely visible, per live feedback). `ConnectionRenderer::ValueChanged()` now reads PenSize/FillColor back out of it and `Draw*()` uses the result.