### PR TITLE
Fix changed-nodes set never actually clearing

### DIFF
--- a/src/app/Commands/PCommandManager.cpp
+++ b/src/app/Commands/PCommandManager.cpp
@@ -212,8 +212,7 @@ status_t PCommandManager::Execute(BMessage *settings) {
 	DEBUG_ONLY(settings->PrintToStream());
 	status_t	err	= doc->LockWithTimeout(TIMEOUT_LOCK);
 	if (err == B_OK) {
-		//(doc->GetChangedNodes())->MakeEmpty();
-		(doc->GetChangedNodes())->empty();
+		(doc->GetChangedNodes())->clear();
 		bool		shadow				= false;
 		char		*commandName		= NULL;
 		PCommand	*command			= NULL;
@@ -279,7 +278,7 @@ void PCommandManager::Undo(BMessage *undo) {
 	BMessage		*msg				= NULL;
 	status_t		err					= doc->LockWithTimeout(TIMEOUT_LOCK);
 	if (err == B_OK) {
-		(doc->GetChangedNodes())->empty();
+		(doc->GetChangedNodes())->clear();
 		if (index<0)
 			index=undoStatus;
 		while (i>=index) {
@@ -313,7 +312,7 @@ void PCommandManager::Redo(BMessage *redo) {
 	BMessage		*msg			= NULL;
 	status_t		err				= doc->LockWithTimeout(TIMEOUT_LOCK);
 	if (err == B_OK) {
-		(doc->GetChangedNodes())->empty();
+		(doc->GetChangedNodes())->clear();
 		if (index<0)
 			index=undoStatus+1;
 		while (i<=index) {


### PR DESCRIPTION
## Summary
- `PCommandManager::Execute()`/`Undo()`/`Redo()` called `(doc->GetChangedNodes())->empty()` at the start of each command, intending to reset the changed-nodes tracking set for the new command
- `std::set::empty()` is a const query (returns bool), not a mutator - the set never actually cleared, so it silently accumulated every node touched across the whole session instead of resetting per command
- Found while investigating #61 with the 2200-node stress fixture; unrelated to that issue's actual symptom, but a real, confirmed bug matching the accumulation problem already noted in the architecture docs

## Test plan
- [x] `./dev.sh build`
- [x] `./dev.sh test` (9/9 passing)
- [x] `./dev.sh smoke`