### PR TITLE
Fix ConfigManager::SaveConfig() never actually writing settings

### DIFF
--- a/src/app/Config/ConfigManager.cpp
+++ b/src/app/Config/ConfigManager.cpp
@@ -80,7 +80,7 @@ void ConfigManager::SaveConfig(){
 	DEBUG_ONLY(config->PrintToStream());
 	MessageXmlWriter messageXml = MessageXmlWriter();
 	messageXml.SetTo(*path);
-	if (messageXml.InitCheck())
+	if (messageXml.InitCheck() == B_OK)
         messageXml.Write(*config);
 }
 


### PR DESCRIPTION
## Summary
- \`ConfigManager::SaveConfig()\`'s \`if (messageXml.InitCheck())\` is inverted - \`InitCheck()\` returns \`B_OK\` (0, falsy) on success, so \`Write()\` only ran on the error path
- Confirmed via the settings file's mtime staying frozen at Aug 1 despite many \`SaveConfig()\` calls since - Shortcuts, MacroShortcuts, and AutoSave settings have never actually survived an app restart
- Found while building #11 (remembered window frame / recent documents), which needs this to work at all

## Test plan
- [x] \`./dev.sh build\`
- [x] \`./dev.sh test\` (9/9)
- [x] Manually confirmed: settings file mtime updates and contains real data after quit, once this fix is in place