### PR TITLE
Remember window size/position across restarts

### DIFF
--- a/src/app/Document/PDocument.cpp
+++ b/src/app/Document/PDocument.cpp
@@ -20,6 +20,7 @@
 #include "PDocLoader.h"
 #include "PDocumentManager.h"
 #include "PluginManager.h"
+#include "ProjectConceptor.h"
 
 
 #undef B_TRANSLATION_CONTEXT
@@ -290,6 +291,19 @@ void PDocument::Init(){
 	BScreen *tmpScreen	= new BScreen();
 	BRect	windowRect	= tmpScreen->Frame();
 	windowRect.InsetBy(50,50);
+	// restore the window frame remembered from the last time a window was
+	// closed, if it still falls within the current screen (a stored frame
+	// from a since-disconnected second monitor would otherwise open the
+	// window off-screen)
+	ConfigManager	*configManager	= ((ProjektConceptor*)be_app)->GetConfigManager();
+	BMessage		*frameConfig	= configManager->GetConfigMessage(P_C_CONFIG_WINDOW_FRAME_FIELD);
+	if (frameConfig != NULL) {
+		BRect	rememberedFrame;
+		if ( (frameConfig->FindRect("frame",&rememberedFrame) == B_OK)
+			&& (tmpScreen->Frame().Contains(rememberedFrame.LeftTop())) )
+			windowRect	= rememberedFrame;
+		delete frameConfig;
+	}
 	window			= new PWindow(windowRect,this);
 	ApplyAutoSaveSettings();
 	if (locked)
@@ -730,6 +744,11 @@ bool PDocument::QuitRequested(void)
 			Unlock();
 	}
 	if (returnValue == true) {
+		BMessage		frameConfig;
+		frameConfig.AddRect("frame",window->Frame());
+		ConfigManager	*configManager	= ((ProjektConceptor*)be_app)->GetConfigManager();
+		configManager->SetConfigMessage(P_C_CONFIG_WINDOW_FRAME_FIELD,&frameConfig);
+		configManager->SaveConfig();
 		window->SetClosing(true);
 		window->Lock();
 		window->Quit();

--- a/src/app/ProjectConceptorDefs.cpp
+++ b/src/app/ProjectConceptorDefs.cpp
@@ -25,6 +25,8 @@ const char*		P_C_SHORTCUT_MODIFIERS_FIELD	= "modifiers";
 const char*		P_C_CONFIG_MACRO_SHORTCUTS_FIELD	= "MacroShortcuts";
 const char*		P_C_MACRO_SHORTCUT_NAME_FIELD		= "macroName";
 
+const char*		P_C_CONFIG_WINDOW_FRAME_FIELD		= "WindowFrame";
+
 
 
 const char*		P_MENU_APP_HELP					= B_TRANSLATE("Help");

--- a/src/include/ProjectConceptorDefs.h
+++ b/src/include/ProjectConceptorDefs.h
@@ -332,6 +332,12 @@ extern const char*		P_C_SHORTCUT_MODIFIERS_FIELD;//	= "modifiers"
 extern const char*		P_C_CONFIG_MACRO_SHORTCUTS_FIELD;//	= "MacroShortcuts"
 extern const char*		P_C_MACRO_SHORTCUT_NAME_FIELD;//		= "macroName"
 
+/** Field name for the app-wide remembered window frame in ConfigManager
+ * (a BMessage holding a single BRect "frame" field) - restored for new
+ * document windows, updated when a window closes.
+ */
+extern const char*		P_C_CONFIG_WINDOW_FRAME_FIELD;//		= "WindowFrame"
+
 
 #endif
 


### PR DESCRIPTION
## Summary
- \`PDocument::Init()\` restores the last-closed window's frame from \`ConfigManager\` (new \`P_C_CONFIG_WINDOW_FRAME_FIELD\`) if one is stored and still falls on the current screen; otherwise falls back to today's default (screen frame inset by 50,50)
- \`PDocument::QuitRequested()\` persists the current frame right before the window closes
- Stacked on #89 (the \`ConfigManager\` persistence fix) - without it, nothing here would actually survive a restart
- Part of #11

## Test plan
- [x] \`./dev.sh build\` / \`./dev.sh test\` (9/9)
- [x] Live-verified both directions: quit, confirmed \`WindowFrame\` appears in the settings file with the real captured rect; manually injected a distinct test rect into the settings file and confirmed a fresh launch opens the window at that exact position/size