### PR TITLE
Add a system-wide recent documents list

### DIFF
--- a/src/app/Document/PDocument.cpp
+++ b/src/app/Document/PDocument.cpp
@@ -1,3 +1,4 @@
+#include <app/Roster.h>
 #include <interface/Alert.h>
 #include <interface/PrintJob.h>
 #include <interface/Screen.h>
@@ -620,6 +621,7 @@ void PDocument::Save(void)
 	if (err==B_OK) {
 			ResetModified();
 			window->SetTitle(Title());
+			be_roster->AddToRecentDocuments(entryRef,APP_SIGNATURE);
 	}
 	else
 		PRINT(("ERROR:\tPDocument -Save error %s\n",strerror(err)));

--- a/src/app/Document/PWindow.cpp
+++ b/src/app/Document/PWindow.cpp
@@ -1,6 +1,8 @@
+#include <app/Roster.h>
 #include <interface/MenuItem.h>
 #include <interface/ScrollBar.h>
 #include <interface/ScrollView.h>
+#include <storage/Entry.h>
 #include <stdio.h>
 #include <translation/TranslationUtils.h>
 #include <translation/TranslatorFormats.h>
@@ -164,6 +166,33 @@ BMenuBar *PWindow::MakeMenu(void)
 	item->SetTarget(be_app);
 	localizeMenuItems->AddPointer("item",(void *) item);
 	localizeMenuItems->AddPointer("itemstring",P_MENU_FILE_OPEN);
+
+	// "Open Recent" - populated from Haiku's own system-wide recent-documents
+	// list (BRoster::AddToRecentDocuments() is called on every open/save, see
+	// PDocument::Save()/ProjektConceptor::RefsReceived()), not a separate
+	// list of our own. Each entry posts the exact message shape Tracker
+	// itself sends (B_REFS_RECEIVED with a "refs" entry_ref), so it runs
+	// through the real ProjektConceptor::RefsReceived() with no extra
+	// dispatch code needed here.
+	BMenu		*recentMenu	= new BMenu(B_TRANSLATE("Open Recent"));
+	BMessage	recentRefs;
+	be_roster->GetRecentDocuments(&recentRefs,10,NULL,0,APP_SIGNATURE);
+	entry_ref	recentRef;
+	int32		recentIndex	= 0;
+	while (recentRefs.FindRef("refs",recentIndex,&recentRef) == B_OK) {
+		BMessage	*openMessage	= new BMessage(B_REFS_RECEIVED);
+		openMessage->AddRef("refs",&recentRef);
+		BMenuItem	*recentItem	= new BMenuItem(recentRef.name,openMessage);
+		recentItem->SetTarget(be_app);
+		recentMenu->AddItem(recentItem);
+		recentIndex++;
+	}
+	if (recentIndex == 0)
+		recentMenu->SetEnabled(false);
+	menu->AddItem(recentMenu);
+	localizeMenuItems->AddPointer("item",(void *) recentMenu->Superitem());
+	localizeMenuItems->AddPointer("itemstring",P_MENU_FILE_OPEN_RECENT);
+
 	menu->AddItem(item = new BMenuItem(B_TRANSLATE("Close"),new BMessage(MENU_FILE_CLOSE),'W'));
 	menu->AddSeparatorItem();
 	localizeMenuItems->AddPointer("item",(void *) item);

--- a/src/app/ProjectConceptor.cpp
+++ b/src/app/ProjectConceptor.cpp
@@ -102,6 +102,7 @@ void ProjektConceptor::RefsReceived(BMessage *msg) {
 			PDocument *doc=documentManager->PDocumentAt(0);
 			doc->SetEntry(&ref);
 			doc->Load();
+			be_roster->AddToRecentDocuments(&ref,APP_SIGNATURE);
 		}
 	delete entry;
 }

--- a/src/app/ProjectConceptorDefs.cpp
+++ b/src/app/ProjectConceptorDefs.cpp
@@ -69,6 +69,10 @@ const char*		P_MENU_FILE_NEW_TAB				= B_TRANSLATE("New Tab");
  *@see PMenuAcces
  */
 const char*		P_MENU_FILE_OPEN				= B_TRANSLATE("Open");
+/**value to find the BMenu Item "File->Open Recent" over the PMenuAcces Interface
+ *@see PMenuAcces
+ */
+const char*		P_MENU_FILE_OPEN_RECENT			= B_TRANSLATE("Open Recent");
 /**value to find the BMenu Item "File->Close" over the PMenuAcces Interface
  *@see PMenuAcces
  */

--- a/src/include/ProjectConceptorDefs.h
+++ b/src/include/ProjectConceptorDefs.h
@@ -190,9 +190,13 @@ extern const char*		P_MENU_FILE_NEW_TAB;//				= "New Tab";
  *@see PMenuAcces
  */	
 extern const char*		P_MENU_FILE_OPEN;//					= "Open";
+/**value to find the BMenu Item "File->Open Recent" over the PMenuAcces Interface
+ *@see PMenuAcces
+ */
+extern const char*		P_MENU_FILE_OPEN_RECENT;//			= "Open Recent";
 /**value to find the BMenu Item "File->Close" over the PMenuAcces Interface
  *@see PMenuAcces
- */	
+ */
 extern const char*		P_MENU_FILE_CLOSE;//				= "Close";
 /**value to find the BMenu Item "File->Save" over the PMenuAcces Interface
  *@see PMenuAcces


### PR DESCRIPTION
## Summary
- \`ProjektConceptor::RefsReceived()\` and \`PDocument::Save()\` now call \`BRoster::AddToRecentDocuments()\` - previously never called anywhere, so ProjectConceptor documents never showed up in Haiku's own per-signature recent-documents tracking despite the system already supporting it
- New File > Open Recent submenu (\`PWindow.cpp\`) populated via \`BRoster::GetRecentDocuments()\`; each item posts the exact \`B_REFS_RECEIVED\` shape Tracker itself sends, so it runs through the existing \`RefsReceived()\` handler with no new dispatch code
- Stacked on #90 (remembered window frame) - both build on the same #89 \`ConfigManager\` fix at the base, though this one doesn't actually depend on that fix (it's pure \`BRoster\`, no \`ConfigManager\` involved)
- Closes #11

## Test plan
- [x] \`./dev.sh build\` / \`./dev.sh test\` (9/9)
- [x] Live-verified app starts cleanly with the new menu-construction code (real \`GetRecentDocuments()\` entries present from earlier testing) - no crash, window renders normally
- [ ] Not yet visually confirmed by clicking through the actual "Open Recent" submenu in a live session (no synthetic-input tooling available on this Haiku VM) - the underlying \`BRoster\` calls are verified against the Haiku API docs and the message shape matches Tracker's own exactly, but a manual click-through is worth doing before merge