### PR TITLE
Add a settings toggle for remembering window size/position

### DIFF
--- a/src/app/Config/ConfigView.cpp
+++ b/src/app/Config/ConfigView.cpp
@@ -12,7 +12,9 @@
 #include <stdlib.h>
 
 
+#include "ConfigManager.h"
 #include "ConfigView.h"
+#include "ProjectConceptor.h"
 #include "ProjectConceptorDefs.h"
 
 //#include "MessageItem.h"
@@ -27,6 +29,7 @@ void ConfigView::Init(){
     BGridLayout     *gridLayout = GridLayout();
     autoSaveCheckBox        = new BCheckBox(NULL,new BMessage(AUTOSAVE_TOGGLED));
     autoSaveIntervalControl = new BTextControl("AutoSave","Autosaveintervall", "5", new BMessage(AUTOSAVE_CHANGED));
+    rememberWindowFrameCheckBox = new BCheckBox(NULL,new BMessage(REMEMBER_WINDOW_FRAME_TOGGLED));
 
     // row 1
    gridLayout->AddView(new BStringView("CheckBoxLabel","Autosave enabled"), 0, 0);
@@ -35,7 +38,12 @@ void ConfigView::Init(){
    //row 2
    gridLayout->AddItem(autoSaveIntervalControl->CreateLabelLayoutItem(), 0, 1);
    gridLayout->AddItem(autoSaveIntervalControl->CreateTextViewLayoutItem(), 1, 1);
-   gridLayout->AddItem(BSpaceLayoutItem::CreateGlue(),0,2);
+
+   //row 3
+   gridLayout->AddView(new BStringView("RememberWindowLabel","Remember window size/position"), 0, 2);
+   gridLayout->AddView(rememberWindowFrameCheckBox, 1, 2);
+
+   gridLayout->AddItem(BSpaceLayoutItem::CreateGlue(),0,3);
 }
 
 void ConfigView::AttachedToWindow(void){
@@ -44,6 +52,7 @@ void ConfigView::AttachedToWindow(void){
 	// to this view instead so MessageReceived() below actually sees them
 	autoSaveCheckBox->SetTarget(this);
 	autoSaveIntervalControl->SetTarget(this);
+	rememberWindowFrameCheckBox->SetTarget(this);
 }
 
 void ConfigView::ChangeLanguage(){
@@ -59,6 +68,18 @@ void ConfigView::SetConfigMessage(BMessage *configureMessage, BMessenger docTarg
 
 void ConfigView::ValueChanged(void){
 	TRACE();
+	// app-wide, independent of configMessage (which is per-document) -
+	// refreshed here too since this runs whenever the settings window is
+	// shown, same as the per-document fields below
+	ConfigManager	*configManager		= ((ProjektConceptor*)be_app)->GetConfigManager();
+	BMessage		*frameConfig		= configManager->GetConfigMessage(P_C_CONFIG_WINDOW_FRAME_FIELD);
+	bool			rememberEnabled		= true;
+	if (frameConfig != NULL) {
+		frameConfig->FindBool(P_C_WINDOW_FRAME_REMEMBER_FIELD,&rememberEnabled);
+		delete frameConfig;
+	}
+	rememberWindowFrameCheckBox->SetValue(rememberEnabled ? B_CONTROL_ON : B_CONTROL_OFF);
+
 	if (configMessage == NULL)
 		return;
 	bool	enabled		= true;
@@ -85,6 +106,21 @@ void ConfigView::MessageReceived(BMessage *msg){
 				configMessage->AddBool(P_C_DOC_AUTOSAVE_ENABLED,enabled);
 			autoSaveIntervalControl->SetEnabled(enabled);
 			documentTarget.SendMessage(P_C_DOC_SETTINGS_CHANGED);
+			break;
+		}
+		case REMEMBER_WINDOW_FRAME_TOGGLED: {
+			bool			enabled			= (rememberWindowFrameCheckBox->Value() == B_CONTROL_ON);
+			ConfigManager	*configManager	= ((ProjektConceptor*)be_app)->GetConfigManager();
+			BMessage		*frameConfig	= configManager->GetConfigMessage(P_C_CONFIG_WINDOW_FRAME_FIELD);
+			BMessage		newFrameConfig;
+			if (frameConfig != NULL) {
+				newFrameConfig	= *frameConfig;
+				delete frameConfig;
+			}
+			if (newFrameConfig.ReplaceBool(P_C_WINDOW_FRAME_REMEMBER_FIELD,enabled) != B_OK)
+				newFrameConfig.AddBool(P_C_WINDOW_FRAME_REMEMBER_FIELD,enabled);
+			configManager->SetConfigMessage(P_C_CONFIG_WINDOW_FRAME_FIELD,&newFrameConfig);
+			configManager->SaveConfig();
 			break;
 		}
 		case AUTOSAVE_CHANGED: {

--- a/src/app/Config/ConfigView.h
+++ b/src/app/Config/ConfigView.h
@@ -21,9 +21,10 @@ class BTextControl;
  * @bug dont work :-)
  */
 
-const uint32 MESSAGE_SELECTED	= 'MEsl';
-const uint32 AUTOSAVE_CHANGED	= 'AScg';
-const uint32 AUTOSAVE_TOGGLED	= 'AStg';
+const uint32 MESSAGE_SELECTED				= 'MEsl';
+const uint32 AUTOSAVE_CHANGED				= 'AScg';
+const uint32 AUTOSAVE_TOGGLED				= 'AStg';
+const uint32 REMEMBER_WINDOW_FRAME_TOGGLED	= 'RWft';
 
 
 class ConfigView : public BGridView
@@ -49,5 +50,8 @@ private:
         BMessenger			documentTarget;
         BCheckBox			*autoSaveCheckBox;
         BTextControl		*autoSaveIntervalControl;
+        // app-wide, unlike the two above - reads/writes ConfigManager
+        // directly rather than the per-document configMessage
+        BCheckBox			*rememberWindowFrameCheckBox;
 };
 #endif

--- a/src/app/Document/PDocument.cpp
+++ b/src/app/Document/PDocument.cpp
@@ -292,14 +292,16 @@ void PDocument::Init(){
 	BRect	windowRect	= tmpScreen->Frame();
 	windowRect.InsetBy(50,50);
 	// restore the window frame remembered from the last time a window was
-	// closed, if it still falls within the current screen (a stored frame
-	// from a since-disconnected second monitor would otherwise open the
-	// window off-screen)
+	// closed, if the user hasn't turned that off and it still falls within
+	// the current screen (a stored frame from a since-disconnected second
+	// monitor would otherwise open the window off-screen)
 	ConfigManager	*configManager	= ((ProjektConceptor*)be_app)->GetConfigManager();
 	BMessage		*frameConfig	= configManager->GetConfigMessage(P_C_CONFIG_WINDOW_FRAME_FIELD);
 	if (frameConfig != NULL) {
+		bool	rememberEnabled	= true;
 		BRect	rememberedFrame;
-		if ( (frameConfig->FindRect("frame",&rememberedFrame) == B_OK)
+		if ( (frameConfig->FindBool(P_C_WINDOW_FRAME_REMEMBER_FIELD,&rememberEnabled) != B_OK || rememberEnabled)
+			&& (frameConfig->FindRect(P_C_WINDOW_FRAME_RECT_FIELD,&rememberedFrame) == B_OK)
 			&& (tmpScreen->Frame().Contains(rememberedFrame.LeftTop())) )
 			windowRect	= rememberedFrame;
 		delete frameConfig;
@@ -744,11 +746,22 @@ bool PDocument::QuitRequested(void)
 			Unlock();
 	}
 	if (returnValue == true) {
-		BMessage		frameConfig;
-		frameConfig.AddRect("frame",window->Frame());
-		ConfigManager	*configManager	= ((ProjektConceptor*)be_app)->GetConfigManager();
-		configManager->SetConfigMessage(P_C_CONFIG_WINDOW_FRAME_FIELD,&frameConfig);
-		configManager->SaveConfig();
+		ConfigManager	*configManager		= ((ProjektConceptor*)be_app)->GetConfigManager();
+		BMessage		*existingConfig		= configManager->GetConfigMessage(P_C_CONFIG_WINDOW_FRAME_FIELD);
+		bool			rememberEnabled		= true;
+		if (existingConfig != NULL) {
+			existingConfig->FindBool(P_C_WINDOW_FRAME_REMEMBER_FIELD,&rememberEnabled);
+			delete existingConfig;
+		}
+		// a disabled toggle just stops updating the remembered frame - it
+		// doesn't erase whatever was last stored, so turning it back on
+		// later resumes from that position rather than losing it
+		if (rememberEnabled) {
+			BMessage	frameConfig;
+			frameConfig.AddRect(P_C_WINDOW_FRAME_RECT_FIELD,window->Frame());
+			configManager->SetConfigMessage(P_C_CONFIG_WINDOW_FRAME_FIELD,&frameConfig);
+			configManager->SaveConfig();
+		}
 		window->SetClosing(true);
 		window->Lock();
 		window->Quit();

--- a/src/app/ProjectConceptorDefs.cpp
+++ b/src/app/ProjectConceptorDefs.cpp
@@ -26,6 +26,8 @@ const char*		P_C_CONFIG_MACRO_SHORTCUTS_FIELD	= "MacroShortcuts";
 const char*		P_C_MACRO_SHORTCUT_NAME_FIELD		= "macroName";
 
 const char*		P_C_CONFIG_WINDOW_FRAME_FIELD		= "WindowFrame";
+const char*		P_C_WINDOW_FRAME_RECT_FIELD		= "frame";
+const char*		P_C_WINDOW_FRAME_REMEMBER_FIELD	= "remember";
 
 
 

--- a/src/include/ProjectConceptorDefs.h
+++ b/src/include/ProjectConceptorDefs.h
@@ -332,11 +332,14 @@ extern const char*		P_C_SHORTCUT_MODIFIERS_FIELD;//	= "modifiers"
 extern const char*		P_C_CONFIG_MACRO_SHORTCUTS_FIELD;//	= "MacroShortcuts"
 extern const char*		P_C_MACRO_SHORTCUT_NAME_FIELD;//		= "macroName"
 
-/** Field name for the app-wide remembered window frame in ConfigManager
- * (a BMessage holding a single BRect "frame" field) - restored for new
- * document windows, updated when a window closes.
+/** Field names inside the app-wide remembered-window-frame ConfigManager
+ * entry: "frame" (BRect) is restored for new document windows and
+ * updated when a window closes; "remember" (bool, defaults to true -
+ * today's always-on behavior - when absent) gates both directions.
  */
 extern const char*		P_C_CONFIG_WINDOW_FRAME_FIELD;//		= "WindowFrame"
+extern const char*		P_C_WINDOW_FRAME_RECT_FIELD;//			= "frame"
+extern const char*		P_C_WINDOW_FRAME_REMEMBER_FIELD;//		= "remember"
 
 
 #endif


### PR DESCRIPTION
## Summary
- New checkbox on the Main Settings tab ("Remember window size/position"), backed by \`ConfigManager\` directly (app-wide, unlike the per-document Autosave controls it sits next to)
- Disabling it stops updating the remembered frame on quit without erasing whatever was last stored - re-enabling it resumes from that position rather than losing it
- Named the previously-inline \`"frame"\` field as a constant (\`P_C_WINDOW_FRAME_RECT_FIELD\`) while touching this code
- Stacked on #90 (this branch's parent) since it extends that feature directly

## Test plan
- [x] \`./dev.sh build\` / \`./dev.sh test\` (9/9)
- [x] Live-verified via direct settings-file manipulation (temporary diagnostic print, reverted before commit): with \`remember=false\` injected, a fresh launch correctly ignored the stored frame and used the default rect instead; quitting from that state left the stored frame untouched (confirmed byte-identical); removing the override (defaulting back to enabled) correctly restored the stored frame again
- [ ] Wanted to also confirm the persist-resumes-when-re-enabled direction live, but hit a `quit` that never completed partway through (VM-level flakiness - screenshot capture was also broken at the same time, unrelated to this change, recovered after `./dev.sh stop`). The persist path itself is the same `SetConfigMessage`/`SaveConfig` pair already verified working in #90, just wrapped in the same `if (rememberEnabled)` gate proven correct on the restore side - logically sound, but worth a live click-through on your end to be sure