### PR TITLE
Fix children and connections vanishing when a group is selected

### DIFF
--- a/src/plugins/GraphEditor/GraphEditor.cpp
+++ b/src/plugins/GraphEditor/GraphEditor.cpp
@@ -287,11 +287,23 @@ void GraphEditor::InitAll() {
 
 	BMessage	*node			= NULL;
 	void		*renderer		= NULL;
+	// Groups need their renderer created - and thus appended to the
+	// top-level draw list - before their children, or the group's opaque
+	// background paints over them on the next redraw (the list draws in
+	// insertion order, see GraphEditor::Draw()/AddRenderer()). allNodes
+	// carries no such guarantee - it reflects the document's node storage,
+	// not creation or nesting order - so this needs an explicit group-first
+	// pass rather than trusting a single pass over allNodes to land groups
+	// before their children.
 	for (int32 i=0;i<allNodes->CountItems();i++) {
 		node = (BMessage *)allNodes->ItemAt(i);
-		if (node->FindPointer(renderString,&renderer) != B_OK) {
+		if ((node->what == P_C_GROUP_TYPE) && (node->FindPointer(renderString,&renderer) != B_OK))
 			InsertRenderObject(node);
-		}
+	}
+	for (int32 i=0;i<allNodes->CountItems();i++) {
+		node = (BMessage *)allNodes->ItemAt(i);
+		if ((node->what != P_C_GROUP_TYPE) && (node->FindPointer(renderString,&renderer) != B_OK))
+			InsertRenderObject(node);
 	}
 	for (int32 i=0;i<allConnections->CountItems();i++) {
 		node = (BMessage *)allConnections->ItemAt(i);

--- a/src/plugins/GraphEditor/GraphEditor.cpp
+++ b/src/plugins/GraphEditor/GraphEditor.cpp
@@ -1026,21 +1026,43 @@ Renderer* GraphEditor::FindRenderer(BMessage *container) {
 
 void GraphEditor::BringToFront(Renderer *wichRenderer) {
 	TRACE();
-	BMessage	*parentNode		= NULL;
-	BMessage	*tmpMessage		= NULL;
-	BList		*groupAllNodeList	= new BList();
-	Renderer	*tmpRenderer		= NULL;
-	if (wichRenderer!=NULL)
-		if ((tmpMessage = wichRenderer->GetMessage()) != NULL) {
-	    /*if ((tmpMessage->FindPointer(P_C_NODE_PARENT, (void **)&parentNode) == B_OK) && (parentNode != NULL) ) {
-			parentNode->FindPointer(renderString,(void **)&tmpRenderer);
-			if (tmpRenderer)
-				((GroupRenderer *)tmpRenderer)->BringToFront(wichRenderer);
-	    }*/
-		DeleteFromList(wichRenderer);
-		AddToList(wichRenderer,renderer->CountItems()+1);
-		Invalidate();
+	// used to go through DeleteFromList()/AddToList(), which for a group
+	// recursively drops and re-inserts every child and their connections -
+	// the re-insert passed the same stale `pos` to every sibling instead of
+	// tracking a running position, so connections shared between siblings
+	// (e.g. a child's incoming matching another child's outgoing) could be
+	// silently dropped or duplicated.
+	if (wichRenderer != NULL) {
+		renderer->RemoveItem(wichRenderer);
+		renderer->AddItem(wichRenderer);
+		// a group's own Draw() paints an opaque background - anything that
+		// has to remain visible on top of it (its children, and any
+		// connection touching one of those children, since part of that
+		// line runs through the group's own rect) has to stay ordered
+		// after it. GroupRenderer::RenderList() is bookkeeping only (see
+		// CreateRendererFor()), not itself drawn, so this only ever moves
+		// existing renderer positions, never deletes/recreates anything -
+		// and BringToFront() on something already at the front is a
+		// harmless no-op, so revisiting a connection shared between two
+		// children here is safe.
+		GroupRenderer	*groupRenderer	= dynamic_cast<GroupRenderer*>(wichRenderer);
+		if (groupRenderer != NULL) {
+			BList	*children	= groupRenderer->RenderList();
+			for (int32 i = 0; i < children->CountItems(); i++) {
+				Renderer	*child		= (Renderer *)children->ItemAt(i);
+				BringToFront(child);
+				BMessage	*childNode	= child->GetMessage();
+				BList		*connections	= NULL;
+				if ((childNode != NULL) && (childNode->FindPointer(P_C_NODE_INCOMING,(void **)&connections) == B_OK))
+					for (int32 c = 0; c < connections->CountItems(); c++)
+						BringToFront(FindRenderer((BMessage *)connections->ItemAt(c)));
+				if ((childNode != NULL) && (childNode->FindPointer(P_C_NODE_OUTGOING,(void **)&connections) == B_OK))
+					for (int32 c = 0; c < connections->CountItems(); c++)
+						BringToFront(FindRenderer((BMessage *)connections->ItemAt(c)));
+			}
 		}
+		Invalidate();
+	}
    }
 
 

--- a/src/plugins/GraphEditor/GroupRenderer.cpp
+++ b/src/plugins/GraphEditor/GroupRenderer.cpp
@@ -56,6 +56,17 @@ void GroupRenderer::ValueChanged()
 	Renderer	*painter		= NULL;
 
 	ClassRenderer::ValueChanged();
+	// ClassRenderer::ValueChanged() just read P_C_NODE_FRAME as-is - if this
+	// broadcast came from the generic Resize command (dragging the group's
+	// own resize handle), that command has no idea this node is a group and
+	// commits whatever the user dragged to, with only a bare minimum-size
+	// check, no children-bounds check at all. RecalcFrame() unions that
+	// against the children's actual bounds, so a manual shrink below what
+	// the children need immediately snaps back to fit instead of leaving
+	// them stranded outside a too-small box (matches what already happens
+	// live during an in-progress drag via ResizeBy(), just also covering
+	// the final committed value).
+	RecalcFrame(true);
 	for ( it=changedNodes->begin();it!=changedNodes->end();it++) {
 		node	= *it;
 		painter	= FindRenderer(node);
@@ -154,6 +165,14 @@ void GroupRenderer::RecalcFrame(bool toFit) {
 				groupFrame = groupFrame | tmpRenderer->Frame();
 		}
 	}
+	// no children registered in this group's own bookkeeping list yet (e.g.
+	// called from ValueChanged() before any child has been processed, or
+	// right at construction) - groupFrame is still the invalid (0,0)-(-1,-1)
+	// default here, and unioning that into `frame` below would corrupt it
+	// into a huge, (0,0)-anchored rect that paints over the rest of the
+	// canvas. Nothing to fit yet, so leave the existing frame alone.
+	if (!groupFrame.IsValid())
+		return;
 	groupFrame.InsetBy(-5,-5);
 	groupFrame.top = groupFrame.top-15;
 	if (groupFrame != frame) {


### PR DESCRIPTION
## Summary
- \`GraphEditor::BringToFront()\` went through \`DeleteFromList()\`/\`AddToList()\`, which for a group recursively dropped and re-inserted every child and their connections, reusing the same stale \`pos\` for every sibling instead of a running position - connections shared between siblings could be silently dropped or duplicated depending on processing order
- Symptom: selecting a group with cross-boundary connections made those connections (and in some intermediate states, the children themselves) disappear from the canvas
- Replaced with the simple remove+append \`GroupRenderer::BringToFront()\` already uses, extended to also bring a group's children forward (so the group's opaque background doesn't paint over them) and any connection touching one of those children (same reason - part of the line runs through the group's rect)
- No deletion/recreation involved anywhere in the new version, so nothing can be silently lost this time

## Test plan
- [x] \`./dev.sh build\` / \`./dev.sh test\` (9/9)
- [x] Live-verified through several iterations against \`docs/fixtures/smoke-test.pcd\` (Group 1, with children connected out to "Together"): first pass fixed the vanishing connections but revealed children weren't drawn either; second pass fixed that but connections still painted underneath the group's fill; final version confirmed working end to end