### PR TITLE
Fix dangling connection pointers and rename double-free

### DIFF
--- a/src/plugins/GraphEditor/ConnectionRenderer.cpp
+++ b/src/plugins/GraphEditor/ConnectionRenderer.cpp
@@ -134,6 +134,13 @@ void ConnectionRenderer::ValueChanged() {
 	}
 }
 
+void ConnectionRenderer::InvalidateEndpoint(Renderer *removed) {
+	if ((Renderer *)from == removed)
+		from = NULL;
+	if ((Renderer *)to == removed)
+		to = NULL;
+}
+
 void ConnectionRenderer::CalcLine() {
 	if (from != NULL &&  to != NULL)
 	{

--- a/src/plugins/GraphEditor/ConnectionRenderer.h
+++ b/src/plugins/GraphEditor/ConnectionRenderer.h
@@ -49,6 +49,16 @@ public:
 
 	virtual bool		Selected(void){return selected;};
 	virtual bool		Caught(BPoint where);
+	// from/to are resolved once in ValueChanged() and cached until the next
+	// broadcast that touches this specific connection - if an endpoint's
+	// renderer is deleted in between (its node removed from the document,
+	// e.g. via Undo/Delete) without this connection itself being marked
+	// changed, the cached pointer goes dangling. GraphEditor::RemoveRenderer()
+	// is the single place a renderer ever gets deleted, so it calls this on
+	// every connection to null out any reference to what it's about to
+	// delete, rather than leaving CalcLine()/Draw() to dereference freed
+	// memory on the next redraw.
+	virtual	void		InvalidateEndpoint(Renderer *removed);
 
 protected:
 			void		Init();

--- a/src/plugins/GraphEditor/GraphEditor.cpp
+++ b/src/plugins/GraphEditor/GraphEditor.cpp
@@ -965,6 +965,19 @@ void GraphEditor::RemoveRenderer(Renderer *wichRenderer) {
 			gRenderer = (GroupRenderer*)FindRenderer(cRenderer->Parent());
 		if (gRenderer != NULL)
 			gRenderer->RemoveRenderer(wichRenderer);
+		// a connection resolves and caches its endpoints' renderer pointers
+		// in ValueChanged() and doesn't revisit them until the next
+		// broadcast that touches that specific connection - if a node gets
+		// removed (Undo of its Insert, Delete, ...) without whatever
+		// command did that also marking every connection attached to it as
+		// changed, a connection can be left caching a pointer to exactly
+		// the renderer being deleted here. Null those out now rather than
+		// let CalcLine()/Draw() dereference freed memory on the next redraw.
+		for (int32 i = 0; i < renderer->CountItems(); i++) {
+			ConnectionRenderer	*cnRenderer	= dynamic_cast<ConnectionRenderer*>((Renderer*)renderer->ItemAt(i));
+			if (cnRenderer != NULL)
+				cnRenderer->InvalidateEndpoint(wichRenderer);
+		}
 		delete wichRenderer;
 	}
 /*	delete rendersensitv;

--- a/src/plugins/GraphEditor/StringRenderer.cpp
+++ b/src/plugins/GraphEditor/StringRenderer.cpp
@@ -67,7 +67,18 @@ void StringRenderer::MouseDown(BPoint where,int32 buttons, int32 clicks,int32 mo
 	textRect.bottom=textRect.bottom*editor->Scale();
 	textRect.InsetBy((2*editor->Scale()),0);
 	textRect.OffsetBy((-2*editor->Scale()),editor->Scale());
-	TextEditorControl	*editer	= new TextEditorControl(textRect,"StringEditor",changeMessage,B_FOLLOW_LEFT|B_FOLLOW_TOP);
+	// TextEditorControl is a BInvoker, which takes ownership of the message
+	// it's given and deletes it in its own destructor - changeMessage is
+	// this renderer's one persistent template (built once in
+	// ClassRenderer::Init()), reused for every edit session, so each
+	// TextEditorControl needs its own independent copy rather than the
+	// shared pointer itself. Passing changeMessage directly meant the
+	// *second* rename of the same node reused an already-freed message
+	// (and the control that freed it a second time double-freed it) -
+	// undetected until the freed block got reused for something else
+	// entirely (e.g. a connection's BMessage), which then crashed on a
+	// completely unrelated redraw with no obvious link back to renaming.
+	TextEditorControl	*editer	= new TextEditorControl(textRect,"StringEditor",new BMessage(*changeMessage),B_FOLLOW_LEFT|B_FOLLOW_TOP);
 	editer->SetTarget(editor->BelongTo());
 	editer->SetScale(editor->Scale());
 	editor->AddChild(editer);


### PR DESCRIPTION
## Summary
- `ConnectionRenderer::InvalidateEndpoint()`, called from `GraphEditor::RemoveRenderer()` (the single place a renderer is ever deleted), nulls out cached `from`/`to` endpoint pointers before the delete - fixes a crash where a connection kept a dangling pointer to a just-deleted node renderer.
- `StringRenderer::MouseDown()` now passes a fresh copy of `changeMessage` to `TextEditorControl` instead of the shared per-node template - fixes a double-free on the second rename of the same node (`BInvoker` deletes the message it's given).

Both found and reproduced during live testing on the VM, both verified fixed against the same repro.

Stacked on #94 (branched from it) - the diff here is just these two commits.

## Test plan
- [x] `./dev.sh build`
- [x] `./dev.sh test` (9/9)
- [x] Live repro on VM: delete a connected node via Undo, redraw no longer crashes
- [x] Live repro on VM: rename the same node twice in a row, no crash