### PR TITLE
Fix Insert button not connecting new node to selection

### DIFF
--- a/src/plugins/GraphEditor/GraphEditor.cpp
+++ b/src/plugins/GraphEditor/GraphEditor.cpp
@@ -791,13 +791,21 @@ void GraphEditor::MessageReceived(BMessage *message) {
 			break;
 		}
 		case G_E_INSERT_NODE: {
-			BMessage *generatedInsertCommand = GenerateInsertCommand(P_C_CLASS_TYPE);
+			// connected=true: both this and G_E_INSERT_SIBLING are meant to
+			// insert a node connected to the current selection - they never
+			// passed that explicitly, which the missing "if (connected)"
+			// gate (restored earlier - see that fix's notes) happened to
+			// paper over by connecting unconditionally regardless of this
+			// flag's value. Restoring the gate correctly enforced the flag,
+			// which then exposed that these two call sites never actually
+			// set it.
+			BMessage *generatedInsertCommand = GenerateInsertCommand(P_C_CLASS_TYPE,true);
 			if (generatedInsertCommand)
 	            sentTo->SendMessage(generatedInsertCommand);
 			break;
 		}
 		case G_E_INSERT_SIBLING: {
-			BMessage *generatedInsertCommand = GenerateInsertCommand(P_C_CLASS_TYPE);
+			BMessage *generatedInsertCommand = GenerateInsertCommand(P_C_CLASS_TYPE,true);
 			if (generatedInsertCommand)
 				sentTo->SendMessage(generatedInsertCommand);
 			break;


### PR DESCRIPTION
## Summary
- `GenerateInsertCommand()`'s `connected` parameter defaults to `false`. A separate, already-fixed bug (the `if (connected)` gate around the connection logic was commented out) previously masked that `G_E_INSERT_NODE`/`G_E_INSERT_SIBLING` never passed `true` - once that gate was restored, Insert stopped connecting the new node to the current selection. Both call sites now pass `connected=true` explicitly.

Independent of the other open PRs (#94/#95) - no file overlap, based directly on master.

## Test plan
- [x] `./dev.sh build`
- [x] `./dev.sh test` (9/9)
- [x] Live repro on VM: select a node, click Insert, new node is connected to the selection again