### PR TITLE
Fix unresolved symbols in installed translators

### DIFF
--- a/src/app/makefile
+++ b/src/app/makefile
@@ -183,7 +183,6 @@ include $(DEVEL_DIRECTORY)/etc/makefile-engine
 default .DEFAULT:
 	mkdir -p ../../$(APP_DIR)
 	cp -rf $(NAME) ../../$(APP_DIR)
-	ln -sf $(NAME) ../../$(APP_DIR)/ProjectConceptor.a
 	cp -rf ../.PackageInfo ../../bin
 	mkdir -p ../../bin/data/deskbar/menu/Applications
 	ln -sf ../../../../apps/ProjectConceptor/$(NAME) ../../bin/data/deskbar/menu/Applications

--- a/src/translators/FreeMind/ProjectConceptorDefs.cpp
+++ b/src/translators/FreeMind/ProjectConceptorDefs.cpp
@@ -1,0 +1,1 @@
+../../app/ProjectConceptorDefs.cpp

--- a/src/translators/FreeMind/makefile
+++ b/src/translators/FreeMind/makefile
@@ -30,8 +30,9 @@ APP_MIME_SIG = application/x-vnd.ProjectConceptor-FreeMindTranslator
 SRCS= 	FreeMindTranslator.cpp \
 		TranslatorMain.cpp \
 		SettingsManager.cpp \
-		ConfigView.cpp 
-		
+		ConfigView.cpp \
+		ProjectConceptorDefs.cpp
+
 
 		
 #	specify the resource files to use
@@ -48,7 +49,7 @@ RSRCS=
 #		naming scheme you need to specify the path to the library
 #		and it's name
 #		library: my_lib.a entry: my_lib.a or path/my_lib.a
-LIBS= be translation ../../../$(APP_DIR)/ProjectConceptor.a
+LIBS= be translation
 		
 #	specify additional paths to directories following the standard
 #	libXXX.so or libXXX.a naming scheme.  You can specify full paths
@@ -98,7 +99,7 @@ COMPILER_FLAGS =
 
 #	specify additional linker flags
 LINKER_FLAGS =
-#INSTALL_DIR    = /boot/home/config/add-ons/Translators
+INSTALL_DIR    = /boot/home/config/add-ons/Translators
 
 ## include the makefile-engine
 DEVEL_DIRECTORY := \

--- a/src/translators/Standard/ProjectConceptorDefs.cpp
+++ b/src/translators/Standard/ProjectConceptorDefs.cpp
@@ -1,0 +1,1 @@
+../../app/ProjectConceptorDefs.cpp

--- a/src/translators/Standard/makefile
+++ b/src/translators/Standard/makefile
@@ -30,7 +30,8 @@ APP_MIME_SIG = application/x-vnd.ProjectConceptor-Translator
 SRCS= 	StandardTranslator.cpp \
 		TranslatorMain.cpp \
 		SettingsManager.cpp \
-		ConfigView.cpp
+		ConfigView.cpp \
+		ProjectConceptorDefs.cpp
 
 		
 #	specify the resource files to use


### PR DESCRIPTION
## Summary

Fixes #72. Root cause confirms the suspicion raised in that issue and during triage of #73: the translators aren't fully self-contained shared objects.

- `StandardTranslator.cpp`/`FreeMindTranslator.cpp` reference several `extern const char*` constants (`P_C_NODE_CONNECTION_FROM`, `P_C_DOC_FORMAT_VERSION_FIELD`, ...) declared in `ProjectConceptorDefs.h` but only ever *defined* in `ProjectConceptorDefs.cpp` - which neither translator's `SRCS` compiled in.
- This resolved fine when the translator `.so` was loaded from inside the running `ProjectConceptor` process (its own image already provides the symbols), but broke for any other process loading the installed translator standalone (the system `translate` tool, or any app doing `BTranslatorRoster`-based format sniffing) - exactly the reported symptom.
- `FreeMind/makefile` had a prior workaround attempt: linking against `../../../$(APP_DIR)/ProjectConceptor.a`, which `app/makefile` creates via `ln -sf $(NAME) .../ProjectConceptor.a` - a symlink to the app *executable*, not a real static archive, so it didn't reliably embed the symbols. `Standard/makefile` never even got that attempt.

## Fix

Symlink `ProjectConceptorDefs.cpp` into each translator's own directory and compile it directly into both `.so` files, so each is fully self-contained. (Tried a plain `../../app/ProjectConceptorDefs.cpp` `SRCS` entry first - compiles fine for the app itself, but the makefile-engine silently drops the compile step for out-of-directory sources in these translator targets specifically. Not worth chasing further given the symlink works cleanly and matches how every other `SRCS` entry in this codebase is already referenced - same-directory, no path prefix.)

Also removed the now-dead `ProjectConceptor.a` symlink hack from `app/makefile` and FreeMind's `LIBS` reference to it, and uncommented FreeMind's `INSTALL_DIR` (was unset unlike Standard's - separate small bug, same theme).

## Verification

- `nm -D` on both built `.so` files: zero undefined `P_C_*` symbols remain (there were several before).
- `./dev.sh build` / `./dev.sh test` (9/9).
- Confirmed a crash I hit while testing this (`smoke-test-simple.pcd` triggers "incompatible version" → app crash) reproduces identically on a clean `master` baseline with none of these changes - pre-existing, unrelated, not touched here.

## Test plan
- [x] `./dev.sh build`
- [x] `./dev.sh test` (9/9)
- [x] `nm -D` confirms no undefined ProjectConceptor-specific symbols in either translator `.so`
- [x] App still loads/renders documents normally with the modified translators