### PR TITLE
Fix make install/plugins_install/translators_install failing

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -79,7 +79,7 @@ app: pkgupdate app/makefile FORCE
 app_clean:
 	cd app && make clean
 
-app_install: app/makefile FORCE
+app_install: pkgupdate app/makefile FORCE
 	cd app && make install
 
 app_catkeys: app/makefile FORCE

--- a/src/plugins/AddAttributeCommand/makefile
+++ b/src/plugins/AddAttributeCommand/makefile
@@ -105,11 +105,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/ChangeValueCommand/makefile
+++ b/src/plugins/ChangeValueCommand/makefile
@@ -105,11 +105,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/CopyCommand/makefile
+++ b/src/plugins/CopyCommand/makefile
@@ -105,11 +105,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/DeleteCommand/makefile
+++ b/src/plugins/DeleteCommand/makefile
@@ -105,11 +105,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/FindCommand/makefile
+++ b/src/plugins/FindCommand/makefile
@@ -104,11 +104,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/GraphEditor/makefile
+++ b/src/plugins/GraphEditor/makefile
@@ -123,11 +123,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/GroupCommand/makefile
+++ b/src/plugins/GroupCommand/makefile
@@ -104,11 +104,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/InsertCommand/makefile
+++ b/src/plugins/InsertCommand/makefile
@@ -105,11 +105,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/MoveCommand/makefile
+++ b/src/plugins/MoveCommand/makefile
@@ -107,11 +107,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/NavigatorEditor/makefile
+++ b/src/plugins/NavigatorEditor/makefile
@@ -123,11 +123,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/PasteCommand/makefile
+++ b/src/plugins/PasteCommand/makefile
@@ -105,11 +105,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/RemoveAttributeCommand/makefile
+++ b/src/plugins/RemoveAttributeCommand/makefile
@@ -105,11 +105,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/ResizeCommand/makefile
+++ b/src/plugins/ResizeCommand/makefile
@@ -105,11 +105,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/plugins/SelectCommand/makefile
+++ b/src/plugins/SelectCommand/makefile
@@ -105,11 +105,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:

--- a/src/translators/Cpp/makefile
+++ b/src/translators/Cpp/makefile
@@ -99,11 +99,11 @@ COMPILER_FLAGS =
 LINKER_FLAGS =
 INSTALL_DIR    = /boot/home/config/add-ons/Translators
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 ## include the makefile-engine

--- a/src/translators/FreeMind/makefile
+++ b/src/translators/FreeMind/makefile
@@ -109,10 +109,10 @@ default .DEFAULT:
 	mkdir -p ../../../bin/add-ons/Translators
 	cp -rf  $(OBJ_DIR)/$(NAME) ../../../bin/add-ons/Translators
 	
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 

--- a/src/translators/Standard/makefile
+++ b/src/translators/Standard/makefile
@@ -104,11 +104,11 @@ DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
 
-install:: $(NAME)
+install:: default
 	@echo "Copying locale files"
 	@echo $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)
-	@cp -rf ./$(NAME) $(INSTALL_DIR)
+	@cp -rf $(TARGET) $(INSTALL_DIR)
 	@echo "Done copying."
 
 default .DEFAULT:


### PR DESCRIPTION
## Summary

Fixes the two concrete, reproducible bugs from #67 - not the INSTALL_DIR path question, which the issue itself already flags as non-blocking for Beta 1 and which I'm deliberately leaving as a separate follow-up (see below).

**1. `app_install` missing a `pkgupdate` dependency.** Running it standalone (without a prior `make app`) failed on the app's `default` target trying to copy a `.PackageInfo` that pkgupdate never generated, since `app_install` didn't depend on it the way `app` does.

**2. The actual bug behind the reported symptom** ("hardcoded path, recompiles with wrong include flags, fails on missing headers"): every plugin/translator makefile's custom `install:: $(NAME)` target used the bare binary name as prerequisite. Make couldn't always resolve that back to the makefile-engine's own build rule, so it fell through to GNU Make's *built-in* implicit compile rule - recompiling the single source file with zero include flags, failing on missing local headers exactly as described in the issue. Changed the prerequisite to `default` (the already-correct, already-configured build target) across all 17 affected makefiles, removing the ambiguity.

Fixing #2 exposed a second, closely-related bug in the same recipes: they copied from `./$(NAME)` (the plugin's own directory), but the actual build output lives at `$(TARGET)` (`$(OBJ_DIR)/$(NAME)` for these targets). Switched to `$(TARGET)`, matching how makefile-engine's own generic install rule already does it.

## Verification

`make plugins_install` now completes cleanly for all 14 plugins - confirmed by inspecting the copied binaries directly at their configured install location (fresh timestamps, correct sizes), not just a clean exit code.

## Deliberately not addressed here

`INSTALL_DIR` is still unset for the app and several translators/plugins, and where it is set, some paths are stale (Standard translator's `~/config/add-ons/Translators` is read-only under modern Haiku's packagefs). Picking real install locations is a packaging/deployment decision, not a bug fix - discussed with @Paradoxianer, keeping scope to the concrete mechanism bugs for this PR.

## Test plan
- [x] `./dev.sh build` / `./dev.sh test` (9/9) - confirms the normal dev workflow is unaffected
- [x] `make app_install` progresses past the previous `.PackageInfo` failure, reaches the documented "no install directory" message
- [x] `make plugins_install` completes cleanly for all 14 plugins, verified real binaries land at the configured path