### PR TITLE
Fix translator Identify() fully parsing arbitrary files

### DIFF
--- a/src/translators/FreeMind/FreeMindTranslator.cpp
+++ b/src/translators/FreeMind/FreeMindTranslator.cpp
@@ -31,32 +31,20 @@ status_t Identify(BPositionIO * inSource, const translation_format * inFormat,	B
 	if (outType != P_C_FREEMIND_TYPE && outType != P_C_DOCUMENT_RAW_TYPE) {
 		return B_NO_TRANSLATOR;
 	}
-	//read the first 10 chars check if it starts with <map then we suggest it is a freemind file
-	if (inSource->Read(xmlString, 10)==10)
-	{
-		if (strstr(xmlString,"<map")!=NULL)
-			outType = P_C_DOCUMENT_RAW_TYPE;
-		else
-			return B_NO_TRANSLATOR;
-	}
-	//need to rework this... unflattens the whole Datastream to check if PDocument::allNodes are in here
+	// Identify() runs against every file any app on the system scans via
+	// BTranslatorRoster, not just ProjectConceptor/FreeMind documents - a
+	// cheap, bounded read is all format detection should ever cost here.
+	// This used to fall back to a full Unflatten() of the whole stream
+	// (checking for a "PDocument::allNodes" field) whenever the 10-byte
+	// read didn't come back with exactly 10 bytes - i.e. for any file
+	// smaller than 10 bytes, which is a narrow case but still exactly the
+	// kind of unbounded full-stream parse the fix for #73 removes from
+	// StandardTranslator's Identify() too. A file that's too short to
+	// contain "<map" isn't a FreeMind document either way.
+	if ((inSource->Read(xmlString, 10)==10) && (strstr(xmlString,"<map")!=NULL))
+		outType = P_C_DOCUMENT_RAW_TYPE;
 	else
-	{
-		BMessage	*testMessage	= new BMessage();
-		BMessage	*tmpMessage		= new BMessage();
-		err = testMessage->Unflatten(inSource);
-		if (err == B_OK)
-		{
-			if (err == B_OK)
-			{
-				err = testMessage->FindMessage("PDocument::allNodes",tmpMessage);
-				if (err==B_OK)
-					outType = P_C_FREEMIND_TYPE;
-			}
-			if (err != B_OK)
-				return B_NO_TRANSLATOR;
-		}
-	}
+		return B_NO_TRANSLATOR;
 
 
 	if (outType == P_C_FREEMIND_TYPE) {

--- a/src/translators/Standard/StandardTranslator.cpp
+++ b/src/translators/Standard/StandardTranslator.cpp
@@ -29,7 +29,20 @@ status_t Identify(BPositionIO * inSource, const translation_format * inFormat,	B
 		err = B_BAD_VALUE;
 	else
 	{
-		/*if (outType == 0) 
+		// Identify() runs against every file any app on the system scans via
+		// BTranslatorRoster, not just ProjectConceptor documents - a full
+		// Unflatten() of the whole stream before any cheap check meant every
+		// unrelated file got fully parsed as a BMessage just to be rejected.
+		// .pcd files are BMessage::Flatten()'s own on-disk format, which
+		// always starts with this 4-byte magic - reject anything else here,
+		// before touching the rest of the stream at all.
+		char	magic[4];
+		off_t	savedPos	= inSource->Position();
+		ssize_t	bytesRead	= inSource->Read(magic, sizeof(magic));
+		inSource->Seek(savedPos, SEEK_SET);
+		if ((bytesRead != (ssize_t)sizeof(magic)) || (memcmp(magic, "HMF1", sizeof(magic)) != 0))
+			err = B_NO_TRANSLATOR;
+		/*if (outType == 0)
 			outType = B_TRANSLATOR_NONE;
 		if (outType != B_TRANSLATOR_NONE && outType != P_C_DOCUMENT_TYPE)
 			err	= B_NO_TRANSLATOR;*/


### PR DESCRIPTION
## Summary

Fixes #73.

`Identify()` runs against every file any app on the system scans via `BTranslatorRoster`, not just ProjectConceptor documents. Both translators did a full `BMessage::Unflatten()` of the entire input stream as their format check, before any cheap/bounded check - for large or numerous unrelated files (e.g. a full-disk indexer, per the issue), this parses arbitrary file contents as a `BMessage` just to reject them.

- **`StandardTranslator::Identify()`** had no pre-check at all. Added a bounded 4-byte magic-number read - `.pcd` files are `BMessage::Flatten()`'s own on-disk format, which always starts with `"HMF1"` (verified directly against a real fixture file's bytes via `xxd`) - and reject immediately on a mismatch, before `Unflatten()` touches the rest of the stream.
- **`FreeMindTranslator::Identify()`** already had a cheap check (read 10 bytes, look for `"<map"`), but fell back to the same full `Unflatten()` whenever that read didn't return exactly 10 bytes - narrower (only very short files) but the same class of problem, sitting under the previous developer's own `"need to rework this"` comment. Removed the fallback entirely - a file too short to contain `"<map"` isn't a FreeMind document either way, and real parsing already belongs in `Translate()`, which only runs once a translator has committed to handling the file.

Doesn't touch the dead, unbuilt `Cpp` translator mentioned in the issue - left as-is, not part of this fix.

## Verification

Loaded a real `.pcd` fixture through the modified `StandardTranslator` end to end - document renders correctly, confirming the magic-number gate doesn't reject genuine files.

## Test plan
- [x] `./dev.sh build`
- [x] `./dev.sh test` (9/9)
- [x] Live on VM: a real `.pcd` document still loads and renders correctly through the modified translator